### PR TITLE
Improve the way email message is displayed 

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,7 +84,7 @@ def main():
                         "title_link": email_provider,
                         "text": email_content,
                         "fields": [],
-                        "footer": "",
+                        "footer": "Sent to : " + all_to,
                         "footer_icon": "",
                         "ts": timestamp
                     }
@@ -93,11 +93,6 @@ def main():
 
             all_to = ', '.join([i["original"] for i in email["to"]])
             all_cc = ', '.join([i["original"] for i in email["cc"]])
-
-            data["attachments"][0]["fields"].append({
-                "title": "",
-                "value": "Sent To" + all_to
-            })
 
             if all_cc:
                 data["attachments"][0]["fields"].append({

--- a/app.py
+++ b/app.py
@@ -68,7 +68,6 @@ def main():
             email_subject = email["title"]
             email_content = "```" + email["plain_text"] + "```"
             timestamp = email["timestamp"]
-            koss_logo_small = "https://raw.githubusercontent.com/kossiitkgp/design/master/logo/exported/koss-filled-small.png"
 
             all_to = ', '.join([i["original"] for i in email["to"]])
             all_cc = ', '.join([i["original"] for i in email["cc"]])

--- a/app.py
+++ b/app.py
@@ -95,8 +95,8 @@ def main():
             all_cc = ', '.join([i["original"] for i in email["cc"]])
 
             data["attachments"][0]["fields"].append({
-                "title": "Sent To",
-                "value": all_to
+                "title": "",
+                "value": "Sent To" + all_to
             })
 
             if all_cc:

--- a/app.py
+++ b/app.py
@@ -70,6 +70,9 @@ def main():
             timestamp = email["timestamp"]
             koss_logo_small = "https://raw.githubusercontent.com/kossiitkgp/design/master/logo/exported/koss-filled-small.png"
 
+            all_to = ', '.join([i["original"] for i in email["to"]])
+            all_cc = ', '.join([i["original"] for i in email["cc"]])
+            
             data = {
                 "text": "",
                 "attachments": [
@@ -91,8 +94,6 @@ def main():
                 ]
             }
 
-            all_to = ', '.join([i["original"] for i in email["to"]])
-            all_cc = ', '.join([i["original"] for i in email["cc"]])
 
             if all_cc:
                 data["attachments"][0]["fields"].append({

--- a/app.py
+++ b/app.py
@@ -86,7 +86,7 @@ def main():
                         "fields": [],
                         "footer": "",
                         "footer_icon": "",
-                        "ts": "⏰" + timestamp
+                        "ts": timestamp
                     }
                 ]
             }

--- a/app.py
+++ b/app.py
@@ -79,13 +79,13 @@ def main():
                         "pretext": "",
                         "author_name": sender_email,
                         "author_link": email_provider,
-                        # "author_icon": koss_logo_small,
+                        "author_icon": "",
                         "title": email_subject,
                         "title_link": email_provider,
                         "text": email_content,
                         "fields": [],
-                        # "footer": "email-to-slack",
-                        # "footer_icon": koss_logo_small,
+                        "footer": "",
+                        "footer_icon": "",
                         "ts": "⏰" + timestamp
                     }
                 ]

--- a/app.py
+++ b/app.py
@@ -86,7 +86,7 @@ def main():
                         "fields": [],
                         # "footer": "email-to-slack",
                         # "footer_icon": koss_logo_small,
-                        # "ts": timestamp
+                        "ts": "⏰" + timestamp
                     }
                 ]
             }

--- a/app.py
+++ b/app.py
@@ -79,14 +79,14 @@ def main():
                         "pretext": "",
                         "author_name": sender_email,
                         "author_link": email_provider,
-                        "author_icon": koss_logo_small,
+                        # "author_icon": koss_logo_small,
                         "title": email_subject,
                         "title_link": email_provider,
                         "text": email_content,
                         "fields": [],
-                        "footer": "email-to-slack",
-                        "footer_icon": koss_logo_small,
-                        "ts": timestamp
+                        # "footer": "email-to-slack",
+                        # "footer_icon": koss_logo_small,
+                        # "ts": timestamp
                     }
                 ]
             }

--- a/app.py
+++ b/app.py
@@ -77,7 +77,7 @@ def main():
                 "attachments": [
                     {
                         "fallback": "Something went wrong while displaying.",
-                        "color": "#36a64f",
+                        "color": "#2196F3",
                         "pretext": "",
                         "author_name": sender_email,
                         "author_link": email_provider,


### PR DESCRIPTION
I have implemented the following changes:

- Removed unnecessary icons. We do not need the icons everywhere and only content of email matters.
- Sent to is now in the footer in a less obtrusive position
- The color green sends a signal of being complete. This has been changed to blue to represent a notification rather than a success
- All important information is preserved: sender's email, send to email, timestamp, content etc.

Here is a screenshot for the new format of displaying emails:
![screenshot_2019-01-26 random common ideas slack 2](https://user-images.githubusercontent.com/25076171/51790404-d56f8500-21ba-11e9-993b-88ab85a4731b.png)

